### PR TITLE
#4: Add new speed commands to access project files and create project…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ README.AlbOrgMode
 :Precis: Emacs lisp to configure Org-Mode for albcorp
 :Authors: Andrew Lincoln Burrow
 :Contact: albcorp@gmail.com
-:Copyright: 2010-2012, 2015 Andrew Lincoln Burrow
+:Copyright: 2010-2012, 2015-2016 Andrew Lincoln Burrow
 :Version: 0.9.1
 
 --------
@@ -48,7 +48,6 @@ the emacs lisp files.  The repository contains helper scripts to achieve
 these ends.
 
 ``alb-org-mode-start.el``
-
   This emacs lisp code can be sourced from your personal emacs init
   file.  It updates the load path, and sets hooks to load the key map.
 

--- a/alb-org-behavior.el
+++ b/alb-org-behavior.el
@@ -1,7 +1,7 @@
 ;;
 ;; alb-org-mode/alb-org-behavior.el
 ;;
-;;     Copyright (C) 2010-2015 Andrew Lincoln Burrow
+;;     Copyright (C) 2010-2016 Andrew Lincoln Burrow
 ;;
 ;;     This library is free software; you can redistribute it and/or
 ;;     modify it under the terms of the GNU General Public License as
@@ -162,12 +162,12 @@ subexpressions.")
 ;; String functions
 ;;
 
-(defun alb-chomp (str)
-      "Chomp leading and tailing whitespace from STR."
-      (replace-regexp-in-string (rx (or (: bos (* (any " \t\n")))
-                                        (: (* (any " \t\n")) eos)))
-                                ""
-                                str))
+(defun alb-org-chomp (str)
+  "Chomp leading and tailing whitespace from STR."
+  (replace-regexp-in-string (rx (or (: bos (* (any " \t\n")))
+                                    (: (* (any " \t\n")) eos)))
+                            ""
+                            str))
 
 ;;
 ;; Whitespace cleanup

--- a/alb-org-behavior.el
+++ b/alb-org-behavior.el
@@ -990,7 +990,7 @@ first word from each.  This function customises Org-Mode."
 
 This function customises Org-Mode."
   (let* ((props (org-entry-properties))
-         (tags (cdr (assoc "TAGS" props))))
+         (tags (cdr (assoc "ALLTAGS" props))))
     (if (string-match ":\\(act_[^:]*\\):" tags)
         (match-string-no-properties 1 tags))))
 
@@ -999,7 +999,7 @@ This function customises Org-Mode."
 
 This function customises Org-Mode."
   (let* ((props (org-entry-properties))
-         (tags (cdr (assoc "TAGS" props))))
+         (tags (cdr (assoc "ALLTAGS" props))))
     (if (string-match ":\\(@[^:]*\\):" tags)
         (match-string-no-properties 1 tags))))
 

--- a/alb-org-behavior.el
+++ b/alb-org-behavior.el
@@ -1206,42 +1206,6 @@ entry.  This function customises Org-Mode."
 ;; XXX Structure navigation
 ;;
 
-(defun alb-org-end ()
-  "Move to the start of the content beneath the headline
-
-Places the point on the first non-whitespace character after the
-metadata. If there is content, point is placed at the first
-non-whitespace character, and indents the line. Otherwise, it
-ensures there are three blank lines, indents the second blank
-line, and places the cursor at the end of the second blank line."
-  (interactive)
-  (if (org-before-first-heading-p)
-      (outline-next-heading)
-    (outline-back-to-heading))
-  (org-show-entry)
-  (let* ((succ-pos (save-excursion      ; Start of successor headline
-                     (outline-next-heading)
-                     (point)))
-         (eofp-pos (save-excursion      ; End of headline properties
-                     (looking-at alb-re-org-heading)
-                     (goto-char (match-end 0))
-                     (looking-at alb-re-org-metadata)
-                     (match-end 0)))
-         (indt-pos (save-excursion      ; Start of indented content
-                     (goto-char eofp-pos)
-                     (if (looking-at "\\(?:\n[ \t]*\\)*\\([^[:space:]]\\)")
-                         (match-beginning 1)
-                       succ-pos))))
-    (if (< indt-pos succ-pos)
-        (progn (goto-char indt-pos)
-               (indent-according-to-mode))
-      (progn (goto-char eofp-pos)
-             (forward-line)
-             (delete-region (point) succ-pos)
-             (newline 3)
-             (forward-line -2)
-             (indent-according-to-mode)))))
-
 ;;
 ;; XXX Structure navigation
 ;;

--- a/alb-org-behavior.el
+++ b/alb-org-behavior.el
@@ -1203,11 +1203,7 @@ entry.  This function customises Org-Mode."
   (recenter))
 
 ;;
-;; XXX Structure navigation
-;;
-
-;;
-;; XXX Structure navigation
+;; Structure editing
 ;;
 
 (defun alb-org-insert-heading-before ()
@@ -1235,7 +1231,7 @@ entry.  This function customises Org-Mode."
     (insert stars)))
 
 ;;
-;; XXX Structure navigation
+;; Content editing
 ;;
 
 (defun alb-org-newline-before ()
@@ -1250,8 +1246,23 @@ entry.  This function customises Org-Mode."
   (save-excursion (beginning-of-line 2)
                   (newline)))
 
+(defun alb-org-insert-item ()
+  "Insert a list item."
+  (interactive)
+  (org-insert-item nil))
+
+(defun alb-org-insert-checkbox ()
+  "Insert a check boxed list item."
+  (interactive)
+  (org-insert-item t))
+
+(defun alb-org-toggle-checkbox (&optional toggle-presence)
+  "Toggle a check boxed list item."
+  (interactive "P")
+  (org-toggle-checkbox toggle-presence))
+
 ;;
-;; XXX Structure navigation
+;; Meta-data editing
 ;;
 
 (defun alb-org-update-headline-statistics ()
@@ -1289,25 +1300,6 @@ update, removes it. Repairs the positions of the tags."
                   (search-forward "[0/0]")
                   (replace-match "")))))
       (org-set-tags nil t))))
-
-;;
-;; List edits
-;;
-
-(defun alb-org-insert-item ()
-  "Insert a list item."
-  (interactive)
-  (org-insert-item nil))
-
-(defun alb-org-insert-checkbox ()
-  "Insert a check boxed list item."
-  (interactive)
-  (org-insert-item t))
-
-(defun alb-org-toggle-checkbox (&optional toggle-presence)
-  "Toggle a check boxed list item."
-  (interactive "P")
-  (org-toggle-checkbox toggle-presence))
 
 ;; Local Variables:
 ;; mode: emacs-lisp

--- a/alb-org-mode-start.el
+++ b/alb-org-mode-start.el
@@ -1,7 +1,7 @@
 ;;
 ;; alb-org-mode/alb-org-mode-start.el
 ;;
-;;     Copyright (C) 2010-2015 Andrew Lincoln Burrow
+;;     Copyright (C) 2010-2016 Andrew Lincoln Burrow
 ;;
 ;;     This library is free software; you can redistribute it and/or
 ;;     modify it under the terms of the GNU General Public License as
@@ -295,6 +295,9 @@
             ("E" . org-set-effort)
             ("#" . alb-org-update-headline-statistics)
             ("l" . org-store-link)
+            ("Project files")
+            ("~" . alb-org-project-files)
+            ("!" . alb-org-project-readme)
             ("Agenda views")
             ("v" . org-agenda)
             ("Exporting and publishing")


### PR DESCRIPTION
… README

The new functions `alb-org-project-files` and `alb-org-project-readme`
are bound to the speed keys ``~`` and ``!`` respectively.  These
function use the customisation in `alb-org-project-dirname-patterns` to
transform an Org-Mode heading into the filename of a project directory,
and then call `find-name-dired` on this filename.  This allows project
files to be quickly accessed from an Org-Mode heading

These changes also begin the use of the ``alb-org`` customisation group,
so that eventually the hard wired behaviour will be phased out of the
code